### PR TITLE
Fix workflow to use docs directory

### DIFF
--- a/.github/workflows/blog_build.yml
+++ b/.github/workflows/blog_build.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dev_blog
+          git add docs
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/sync-images.yml
+++ b/.github/workflows/sync-images.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Prepare image list
       run: |
-        mkdir -p dev_blog/image/
+        mkdir -p docs/image/
         if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
           echo "初回コミットまたは履歴が無いため、source_img 全部をコピー対象にします"
           find source_img -type f > changed.txt
@@ -26,10 +26,10 @@ jobs:
           git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- source_img/ > changed.txt
         fi
 
-    - name: Copy changed images to dev_blog
+    - name: Copy changed images to docs
       run: |
         while read file; do
-          target="dev_blog/image/${file#source_img/}"
+          target="docs/image/${file#source_img/}"
           mkdir -p "$(dirname "$target")"
           cp "$file" "$target"
           echo "[copy] $file → $target"
@@ -39,6 +39,6 @@ jobs:
       run: |
         git config user.name "github-actions"
         git config user.email "github-actions@users.noreply.github.com"
-        git add dev_blog/image/
+        git add docs/image/
         git commit -m "Auto sync new/updated images" || echo "No changes"
         git push


### PR DESCRIPTION
## Summary
- adjust blog build workflow to commit `docs`
- update image sync workflow to output into `docs/image`

## Testing
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_684806edbd688325b502965460c937da